### PR TITLE
Requesting to remove utexas.edu from stoplist.txt

### DIFF
--- a/lib/domains/stoplist.txt
+++ b/lib/domains/stoplist.txt
@@ -500,7 +500,6 @@ gavilan.edu
 mgccc.edu
 my.jcu.edu.au
 masu.edu.cn
-utexas.edu
 unijos.edu.ng
 cczu.edu.cn
 sdust.edu.cn


### PR DESCRIPTION
The utexas.edu domain belongs to The University of Texas at Austin and can be verified at https://www.utexas.edu/.